### PR TITLE
Update puppet 8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: "Publish module"
 
 on:
   workflow_dispatch:
-  
+ 
 jobs:
   release: 
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_release.yml@main"

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 /spec/fixtures/modules/*
 /tmp/
 /vendor/
+/.vendor/
 /convert_report.txt
 /update_report.txt
 .DS_Store
@@ -26,3 +27,9 @@
 .envrc
 /inventory.yaml
 /spec/fixtures/litmus_inventory.yaml
+.resource_types
+.modules
+.task_cache.json
+.plan_cache.json
+.rerun.json
+bolt-debug.log

--- a/.pdkignore
+++ b/.pdkignore
@@ -19,6 +19,7 @@
 /spec/fixtures/modules/*
 /tmp/
 /vendor/
+/.vendor/
 /convert_report.txt
 /update_report.txt
 .DS_Store
@@ -26,9 +27,16 @@
 .envrc
 /inventory.yaml
 /spec/fixtures/litmus_inventory.yaml
+.resource_types
+.modules
+.task_cache.json
+.plan_cache.json
+.rerun.json
+bolt-debug.log
 /.fixtures.yml
 /Gemfile
 /.gitattributes
+/.github/
 /.gitignore
 /.pdkignore
 /.puppet-lint.rc

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,1 +1,9 @@
+--fail-on-warnings
 --relative
+--no-80chars-check
+--no-140chars-check
+--no-class_inherits_from_params_class-check
+--no-autoloader_layout-check
+--no-documentation-check
+--no-single_quote_string_with_variables-check
+--ignore-paths=.vendor/**/*.pp,.bundle/**/*.pp,pkg/**/*.pp,spec/**/*.pp,tests/**/*.pp,types/**/*.pp,vendor/**/*.pp

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,13 +1,11 @@
 ---
-inherit_from: .rubocop_todo.yml
-
 require:
 - rubocop-performance
 - rubocop-rspec
 AllCops:
   NewCops: enable
   DisplayCopNames: true
-  TargetRubyVersion: '2.7'
+  TargetRubyVersion: '2.6'
   Include:
   - "**/*.rb"
   Exclude:
@@ -530,6 +528,8 @@ Lint/DuplicateBranch:
   Enabled: false
 Lint/DuplicateMagicComment:
   Enabled: false
+Lint/DuplicateMatchPattern:
+  Enabled: false
 Lint/DuplicateRegexpCharacterClassElement:
   Enabled: false
 Lint/EmptyBlock:
@@ -646,6 +646,8 @@ Style/ComparableClamp:
   Enabled: false
 Style/ConcatArrayLiterals:
   Enabled: false
+Style/DataInheritance:
+  Enabled: false
 Style/DirEmpty:
   Enabled: false
 Style/DocumentDynamicEvalDefinition:
@@ -713,6 +715,8 @@ Style/RedundantEach:
 Style/RedundantHeredocDelimiterQuotes:
   Enabled: false
 Style/RedundantInitialize:
+  Enabled: false
+Style/RedundantLineContinuation:
   Enabled: false
 Style/RedundantSelfAssignmentBranch:
   Enabled: false

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
     "puppet.puppet-vscode",
-    "rebornix.Ruby"
+    "Shopify.ruby-lsp"
   ]
 }

--- a/Gemfile
+++ b/Gemfile
@@ -20,26 +20,34 @@ group :development do
   gem "json", '= 2.6.1',                         require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.6.3',                         require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "racc", '~> 1.4.0',                        require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "deep_merge", '~> 1.2.2',                  require: false
   gem "voxpupuli-puppet-lint-plugins", '~> 5.0', require: false
-  gem "facterdb", '~> 1.18',                     require: false
-  gem "metadata-json-lint", '~> 3.0',            require: false
-  gem "puppetlabs_spec_helper", '~> 6.0',        require: false
-  gem "rspec-puppet-facts", '~> 2.0',            require: false
-  gem "codecov", '~> 0.2',                       require: false
+  gem "facterdb", '~> 2.1',                      require: false if Gem::Requirement.create(['< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "facterdb", '~> 3.0',                      require: false if Gem::Requirement.create(['>= 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "metadata-json-lint", '~> 4.0',            require: false
+  gem "json-schema", '< 5.1.1',                  require: false
+  gem "rspec-puppet-facts", '~> 4.0',            require: false if Gem::Requirement.create(['< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "rspec-puppet-facts", '~> 5.0',            require: false if Gem::Requirement.create(['>= 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "dependency_checker", '~> 1.0.0',          require: false
   gem "parallel_tests", '= 3.12.1',              require: false
   gem "pry", '~> 0.10',                          require: false
-  gem "simplecov-console", '~> 0.5',             require: false
+  gem "simplecov-console", '~> 0.9',             require: false
   gem "puppet-debugger", '~> 1.0',               require: false
-  gem "rubocop", '= 1.48.1',                     require: false
+  gem "rubocop", '~> 1.50.0',                    require: false
   gem "rubocop-performance", '= 1.16.0',         require: false
   gem "rubocop-rspec", '= 2.19.0',               require: false
   gem "rb-readline", '= 0.5.5',                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "github_changelog_generator",              require: false
+
+end
+group :development, :release_prep do
+  gem "puppet-strings", '~> 4.0',         require: false
+  gem "puppetlabs_spec_helper", '~> 8.0', require: false
+  gem "puppet-blacksmith", '~> 7.0',      require: false
 end
 group :system_tests do
-  gem "puppet_litmus", '~> 1.0', require: false, platforms: [:ruby, :x64_mingw]
-  gem "serverspec", '~> 2.41',   require: false
+  gem "puppet_litmus", '~> 1.0',   require: false, platforms: [:ruby, :x64_mingw]
+  gem "CFPropertyList", '< 3.0.7', require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "serverspec", '~> 2.41',     require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/Rakefile
+++ b/Rakefile
@@ -41,7 +41,14 @@ def changelog_future_release
 end
 
 PuppetLint.configuration.send('disable_relative')
-
+PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.send('disable_140chars')
+PuppetLint.configuration.send('disable_class_inherits_from_params_class')
+PuppetLint.configuration.send('disable_autoloader_layout')
+PuppetLint.configuration.send('disable_documentation')
+PuppetLint.configuration.send('disable_single_quote_string_with_variables')
+PuppetLint.configuration.fail_on_warnings = true
+PuppetLint.configuration.ignore_paths = [".vendor/**/*.pp", ".bundle/**/*.pp", "pkg/**/*.pp", "spec/**/*.pp", "tests/**/*.pp", "types/**/*.pp", "vendor/**/*.pp"]
 
 if Gem.loaded_specs.key? 'github_changelog_generator'
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|

--- a/lib/puppet/functions/change_window/change_window.rb
+++ b/lib/puppet/functions/change_window/change_window.rb
@@ -34,7 +34,7 @@ Puppet::Functions.create_function(:'change_window::change_window') do
       end
 
       def convert_string_to_int(s)
-        return Integer(s, 10)
+        Integer(s, 10)
       rescue ArgumentError => ex
         raise Puppet::ParseError("window_month range values must be valid integers, got: #{s}")
       end
@@ -58,11 +58,11 @@ Puppet::Functions.create_function(:'change_window::change_window') do
     end
     window_month_val.each do |val|
       if val.is_a?(Integer)
-        if val.between?(1, 12)
-          window_month.push(val)
-        else
-          raise Puppet::ParseError, 'window_month values must be between 1 and 12'
-        end
+        raise Puppet::ParseError, 'window_month values must be between 1 and 12' unless val.between?(1, 12)
+        window_month.push(val)
+
+
+
       end
       next unless val.is_a?(String)
       range = val.split('-')
@@ -140,7 +140,7 @@ Puppet::Functions.create_function(:'change_window::change_window') do
         raise Puppet::ParseError, "Invalid key provided for window_time. Only start/end supported - found #{ts}"
       end
 
-      unless window_time[ts] =~ %r{^\d(\d)?:\d\d$}
+      unless %r{^\d(\d)?:\d\d$}.match?(window_time[ts])
         raise Puppet::ParseError, "Invalid time supplied for window_time #{ts} - found #{window_time[ts]}"
       end
     end

--- a/manifests/apply.pp
+++ b/manifests/apply.pp
@@ -9,8 +9,8 @@
 #   An array of classes to be applied when within the change_window.
 #
 define change_window::apply (
-  $change_window_set,
-  $class_list,
+  Array $change_window_set,
+  Array $class_list,
 ) {
   #Notify Module version
   notify { 'Version 1.0': }

--- a/manifests/apply.pp
+++ b/manifests/apply.pp
@@ -14,9 +14,6 @@ define change_window::apply (
 ) {
   #Notify Module version
   notify { 'Version 1.0': }
-  # Validate arguments
-  validate_array($change_window_set)
-  validate_array($class_list)
 
   # Lookup named schedule
   debug("change_window_set = ${change_window_set}")

--- a/manifests/apply.pp
+++ b/manifests/apply.pp
@@ -32,7 +32,7 @@ define change_window::apply (
   debug("class_list = ${class_list}")
   $class_list.each |$class_entry| {
     # complex class utilizing a hash structure
-    if is_hash($class_entry) {
+    if $class_entry.is_a(Hash) {
       create_resources('class', $class_entry)
 
       # Simple named class

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 2.4.0 < 10.0.0"
+      "version_requirement": ">= 4.10.0 < 10.0.0"
     },
     {
       "name": "trlinkin/noop",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-change_window",
-  "version": "0.2.1",
+  "version": "1.0.0",
   "author": "puppetlabs",
   "summary": "Allows puppet code to be applied during specified change window(s)",
   "license": "Apache-2.0",
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 2.4.0 < 9.0.0"
+      "version_requirement": ">= 2.4.0 < 10.0.0"
     },
     {
       "name": "trlinkin/noop",
@@ -87,7 +87,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.5.10 < 8.0.0"
+      "version_requirement": ">= 5.5.10 < 9.0.0"
     }
   ],
   "tags": [
@@ -95,7 +95,7 @@
     "change window",
     "time"
   ],
-  "pdk-version": "2.5.0",
-  "template-url": "pdk-default#2.5.0",
-  "template-ref": "tags/2.5.0-0-g369d483"
+  "pdk-version": "3.4.0",
+  "template-url": "https://github.com/puppetlabs/pdk-templates#main",
+  "template-ref": "tags/3.4.0.2-0-gd5f5ac1"
 }

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -2,7 +2,8 @@
 #
 # Facts specified here will override the values provided by rspec-puppet-facts.
 ---
-ipaddress: "172.16.254.254"
-ipaddress6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
+networking:
+  ip: "172.16.254.254"
+  ip6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
+  mac: "AA:AA:AA:AA:AA:AA"
 is_pe: false
-macaddress: "AA:AA:AA:AA:AA:AA"

--- a/spec/defines/change_window_apply_spec.rb
+++ b/spec/defines/change_window_apply_spec.rb
@@ -35,7 +35,8 @@ describe 'change_window::apply', type: :define do
     let :params do
       default_params.merge(change_window_set: [
                              ['-05:00', 'window', { 'start' => 'Tuesday', 'end' => 'Thursday' }, { 'start' => '08:00', 'end' => '22:00' }, [1, 2, 3, 4, 5], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12], time],
-                             ['-05:00', 'window', { 'start' => 'Wednesday', 'end' => 'Thursday' }, { 'start' => '22:00', 'end' => '02:00' }, [1, 2, 3, 4, 5], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12], time],
+                             ['-05:00', 'window', { 'start' => 'Wednesday', 'end' => 'Thursday' }, { 'start' => '22:00', 'end' => '02:00' }, [1, 2, 3, 4, 5], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12],
+                              time],
                            ])
     end
 

--- a/spec/defines/change_window_apply_spec.rb
+++ b/spec/defines/change_window_apply_spec.rb
@@ -1,5 +1,8 @@
 require 'spec_helper'
-require 'hiera'
+
+RSpec.configure do |c|
+  c.hiera_config = File.expand_path(File.join(__FILE__, '../fixtures/hiera.yaml'))
+end
 
 time = [2016, 1, 6, 6, 15] # 2016-01-06 06:15 (Wed)
 

--- a/spec/fixtures/modules/test_apply/manifests/init.pp
+++ b/spec/fixtures/modules/test_apply/manifests/init.pp
@@ -1,17 +1,17 @@
-include ::change_window::apply
+include change_window::apply
 #
 # Class test_apply - creates two resources with one set noop and the other not
 class test_apply {
   change_window::apply { 'my_test_set':
     change_window_set => [
-          [ '-05:00', 'window', {'start' => 'Friday', 'end' => 'Monday'}, {'start' => '22:00', 'end' => '02:00' }, [1,2,3,4,5], [1,2,3,4,5,6,7,8,9,10,12]],
-          [ '-05:00', 'window', {'start' => 'Wednesday', 'end' => 'Thursday'}, {'start' => '22:00', 'end' => '02:00' }, [1,2,3,4,5], [1,2,3,4,5,6,7,8,9,10,12]],
-        ],
+      ['-05:00', 'window', { 'start' => 'Friday', 'end' => 'Monday' }, { 'start' => '22:00', 'end' => '02:00' }, [1,2,3,4,5], [1,2,3,4,5,6,7,8,9,10,12]],
+      ['-05:00', 'window', { 'start' => 'Wednesday', 'end' => 'Thursday' }, { 'start' => '22:00', 'end' => '02:00' }, [1,2,3,4,5], [1,2,3,4,5,6,7,8,9,10,12]],
+    ],
     class_list        => [{
-      'test_notify_parameter' => {
-        mesg => 'test_notify_parameter',
-      }
+        'test_notify_parameter' => {
+          mesg => 'test_notify_parameter',
+        }
     }],
   }
-  include ::test_notify_simple
+  include test_notify_simple
 }

--- a/spec/fixtures/modules/test_apply/manifests/init.pp
+++ b/spec/fixtures/modules/test_apply/manifests/init.pp
@@ -1,4 +1,3 @@
-include change_window::apply
 #
 # Class test_apply - creates two resources with one set noop and the other not
 class test_apply {

--- a/spec/fixtures/modules/test_notify_parameter/manifests/init.pp
+++ b/spec/fixtures/modules/test_notify_parameter/manifests/init.pp
@@ -1,10 +1,11 @@
 #
 # Class: test_notify_paramter - creates a notify resource with optionally
 #   specified title.
-class test_notify_parameter(
-  $mesg = 'test_notify_parameter',
+#
+# @param mesg
+#   The message to be displayed by the notify resource.
+class test_notify_parameter (
+  String $mesg = 'test_notify_parameter',
 ) {
-
   notify { $mesg: }
-
 }

--- a/spec/fixtures/modules/test_notify_simple/manifests/init.pp
+++ b/spec/fixtures/modules/test_notify_simple/manifests/init.pp
@@ -1,10 +1,12 @@
 #
 # Class: test_notify_simple - creates a notify resource with optionally
 #   specified title.
-class test_notify_simple(
-  $mesg = 'test_notify_simple',
+#
+# @param mesg
+#   The message to be displayed by the notify resource.
+#
+class test_notify_simple (
+  String $mesg = 'test_notify_simple',
 ) {
-
   notify { $mesg: }
-
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,8 @@ default_fact_files.each do |f|
   next unless File.exist?(f) && File.readable?(f) && File.size?(f)
 
   begin
-    default_facts.merge!(YAML.safe_load(File.read(f), permitted_classes: [], permitted_symbols: [], aliases: true))
+    require 'deep_merge'
+    default_facts.deep_merge!(YAML.safe_load(File.read(f), permitted_classes: [], permitted_symbols: [], aliases: true))
   rescue StandardError => e
     RSpec.configuration.reporter.message "WARNING: Unable to load #{f}: #{e}"
   end
@@ -33,7 +34,7 @@ end
 
 # read default_facts and merge them over what is provided by facterdb
 default_facts.each do |fact, value|
-  add_custom_fact fact, value
+  add_custom_fact fact, value, merge_facts: true
 end
 
 RSpec.configure do |c|


### PR DESCRIPTION
Update module support to version 8 of Puppet
Upgrades to version 3.4 of the PDK
Updates the syntax to match the newer standards
Requires at least StdLib version 4.10 due to use of is_a function
Ups support for StdLib to version 10
Fixes spec tests so that they run in Puppet 8

Removes `"github_changelog_generator"` due to issues with Gem dependency installations